### PR TITLE
Fixed bug where daily processing was not truncating the Event table, …

### DIFF
--- a/ghinsights/USQL/ProcessCommit.usql
+++ b/ghinsights/USQL/ProcessCommit.usql
@@ -4,6 +4,7 @@ REFERENCE ASSEMBLY [Newtonsoft.Json];
 
 @Commit =
 SELECT	 GHInsights.USql.Utility.GetString(Data, "sha") AS CommitSha
+        ,GHInsights.USql.Utility.GetString(Data, "url") AS Url
 		,GHInsights.USql.Utility.GetInteger(Data, "author.id") AS AuthorId
 		,GHInsights.USql.Utility.GetString(Data, "author.login") AS AuthorLogin
 		,GHInsights.USql.Utility.GetBoolean(Data, "author.site_admin") AS AuthorSiteAdmin
@@ -46,6 +47,7 @@ CREATE TABLE dbo.Commit
 )
 AS
 SELECT   CommitSha
+        ,Url
 		,AuthorId
 		,AuthorLogin
 		,AuthorSiteAdmin

--- a/ghinsights/USQL/ProcessDaily.usql
+++ b/ghinsights/USQL/ProcessDaily.usql
@@ -29,6 +29,7 @@ AND   IngestDate == @IngestDatePartition;
 
 @NewCommit =
 SELECT	 CommitSha
+        ,GHInsights.USql.Utility.GetString(Data, "url") AS Url
 		,GHInsights.USql.Utility.GetInteger(Data, "author.id") AS AuthorId
 		,GHInsights.USql.Utility.GetString(Data, "author.login") AS AuthorLogin
 		,GHInsights.USql.Utility.GetBoolean(Data, "author.site_admin") AS AuthorSiteAdmin
@@ -69,6 +70,7 @@ TRUNCATE TABLE dbo.Commit;
 
 INSERT dbo.Commit
 SELECT   CommitSha
+        ,Url
 		,AuthorId
 		,AuthorLogin
 		,AuthorSiteAdmin
@@ -412,6 +414,8 @@ SELECT   *
         ,ROW_NUMBER() OVER (PARTITION BY EventId ORDER BY EtlSourceId DESC) AS RowNumber
 FROM @Event;
 
+TRUNCATE TABLE dbo.Event;
+    
 INSERT dbo.Event
 SELECT   EventId
 		,ActorId


### PR DESCRIPTION
…resulting in the entire set being duplicated each day.  Thanks Shuo for finding this!

Added Url to Commit table as it provides context to which repo the Commits were found.